### PR TITLE
fix line break on darwin

### DIFF
--- a/hosts.js
+++ b/hosts.js
@@ -5,7 +5,7 @@ var fs = require('fs'),
 var lineBreak = {
   'win32': '\r\n',
   'linux': '\n',
-  'darwin': '\r'
+  'darwin': '\n'
 }[platform];
 
 


### PR DESCRIPTION
Sorry I'm not sure what actually `line feed` on darwin is. Some people say it's CR(namely \r) which is LF(\n) when I try it myself. This pull request :( 
